### PR TITLE
fix(frontend): Resolve build and test errors

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -678,18 +678,6 @@
         }
       }
     },
-    "node_modules/@angular-devkit/build-angular/node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.10.0"
-      }
-    },
     "node_modules/@angular-devkit/build-angular/node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -1318,18 +1306,6 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@angular/cli/node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.10.0"
       }
     },
     "node_modules/@angular/cli/node_modules/ansi-escapes": {
@@ -14027,15 +14003,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -8,11 +8,17 @@ import { ConfigService, IMenuItem } from './service/config.service';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
-  constructor(private config: ConfigService, public translate: TranslateService) {translate.addLangs(['hu', 'en']);
-  translate.setDefaultLang('hu');}
-
-  sidebar: IMenuItem[] = this.config.sidebarMenu;
+  sidebar: IMenuItem[];
   title = 'NyelvSzo2.0';
+
+  constructor(
+    private config: ConfigService,
+    public translate: TranslateService
+  ) {
+    this.sidebar = this.config.sidebarMenu;
+    translate.addLangs(['hu', 'en']);
+    translate.setDefaultLang('hu');
+  }
 
   switchLanguage(lang: string){
     this.translate.use(lang);

--- a/frontend/src/app/common/navbar/navbar.component.ts
+++ b/frontend/src/app/common/navbar/navbar.component.ts
@@ -8,12 +8,17 @@ import { AuthService } from 'src/app/service/auth.service';
   styleUrls: ['./navbar.component.scss']
 })
 export class NavbarComponent implements OnInit {
-  user$ = this.auth.user$;
+  user$;
   rights = '';
 
-  constructor(private auth: AuthService,public translate: TranslateService
-  ) {translate.addLangs(['en', 'hu']);
-  translate.setDefaultLang('hu');}
+  constructor(
+    private auth: AuthService,
+    public translate: TranslateService
+  ) {
+    this.user$ = this.auth.user$;
+    translate.addLangs(['en', 'hu']);
+    translate.setDefaultLang('hu');
+  }
 
   ngOnInit(): void {}
 

--- a/frontend/src/app/data-table/ngx-data-table/ngx-data-table.component.spec.ts
+++ b/frontend/src/app/data-table/ngx-data-table/ngx-data-table.component.spec.ts
@@ -3,8 +3,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NgxDataTableComponent } from './ngx-data-table.component';
 
 describe('NgxDataTableComponent', () => {
-  let component: NgxDataTableComponent;
-  let fixture: ComponentFixture<NgxDataTableComponent>;
+  let component: NgxDataTableComponent<any>;
+  let fixture: ComponentFixture<NgxDataTableComponent<any>>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -14,7 +14,7 @@ describe('NgxDataTableComponent', () => {
   });
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(NgxDataTableComponent);
+    fixture = TestBed.createComponent(NgxDataTableComponent<any>);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/frontend/src/app/page/entries/entries.component.ts
+++ b/frontend/src/app/page/entries/entries.component.ts
@@ -11,8 +11,8 @@ import { NotificationService } from 'src/app/service/notification.service';
   styleUrls: ['./entries.component.scss']
 })
 export class EntriesComponent implements OnInit {
-  columns = this.config.entriesTableColumns;
-  list$ = this.entryService.getAll();
+  columns;
+  list$;
   entity = 'Entry';
 
   constructor(
@@ -20,7 +20,10 @@ export class EntriesComponent implements OnInit {
     private entryService: EntryService,
     private router: Router,
     private notifyService: NotificationService
-  ) {}
+  ) {
+    this.columns = this.config.entriesTableColumns;
+    this.list$ = this.entryService.getAll();
+  }
 
   ngOnInit(): void {}
 

--- a/frontend/src/app/page/users/users.component.ts
+++ b/frontend/src/app/page/users/users.component.ts
@@ -11,8 +11,8 @@ import { UserService } from 'src/app/service/user.service';
   styleUrls: ['./users.component.scss']
 })
 export class UsersComponent implements OnInit {
-  columns = this.config.usersTableColumn;
-  list$ = this.userService.getAll();
+  columns;
+  list$;
   entity = 'User';
 
   constructor(
@@ -20,7 +20,10 @@ export class UsersComponent implements OnInit {
     private userService: UserService,
     private router: Router,
     private notifyService: NotificationService
-  ) {}
+  ) {
+    this.columns = this.config.usersTableColumn;
+    this.list$ = this.userService.getAll();
+  }
 
   ngOnInit(): void {}
 

--- a/frontend/src/app/service/base.service.spec.ts
+++ b/frontend/src/app/service/base.service.spec.ts
@@ -3,11 +3,11 @@ import { TestBed } from '@angular/core/testing';
 import { BaseService } from './base.service';
 
 describe('BaseService', () => {
-  let service: BaseService;
+  let service: BaseService<any>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.inject(BaseService);
+    service = TestBed.inject(BaseService<any>);
   });
 
   it('should be created', () => {

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,2 +1,2 @@
 /* You can add global styles to this file, and also import other style files */
-@import '~ngx-toastr/toastr';
+@import 'ngx-toastr/toastr';

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -16,7 +16,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2020",
+    "target": "es2022",
     "module": "es2020",
     "lib": [
       "es2020",


### PR DESCRIPTION
This commit addresses several issues that were causing the build and tests to fail.

- Updates the TypeScript `target` in `tsconfig.json` from `es2020` to `es2022` to resolve a compiler warning.
- Corrects the SASS import path for `ngx-toastr` in `src/styles.scss` to align with the package's exports.
- Fixes `TS2314` generic type errors in `ngx-data-table.component.spec.ts` and `base.service.spec.ts` by providing an `<any>` type argument.
- Refactors several components (`app`, `navbar`, `entries`, `users`) to initialize properties within the constructor, resolving `TS2729` errors related to strict property initialization.